### PR TITLE
Inner vim function for installing gounit binaries

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.vim]
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/README.md
+++ b/README.md
@@ -1,27 +1,51 @@
 # gounit-vim
 
-Vim plugin for [gounit](https://github.com/hexdigest/gounit), that allows
-you to generate table driven tests easily.
-
-## Usage
-Call `:GoUnit` to generate test for function in current line or functions in
-text selected in visual mode.
+Vim plugin for [gounit](https://github.com/hexdigest/gounit) tool, that allows you to generate table driven tests easily.
 
 ## Installation
-gounit-vim requires **gounit** to be available in your `$PATH`. Alternatively you
-can provide path to **gounit** using `g:gounit_bin` setting.
+gounit-vim requires **gounit** to be available in your `$PATH`. Alternatively you can provide path to **gounit** using `g:gounit_bin` setting.
 
 Plugin installation:
-*  [Pathogen](https://github.com/tpope/vim-pathogen)
-  * `git clone https://github.com/buoto/gounit-vim.git ~/.vim/bundle/gounit-vim`
+* [Pathogen](https://github.com/tpope/vim-pathogen)
+    ```
+    git clone https://github.com/hexdigest/gounit-vim.git ~/.vim/bundle/gounit-vim
+    ```
 *  [vim-plug](https://github.com/junegunn/vim-plug)
-  * `Plug 'buoto/gounit-vim'`
+    ```
+    Plug 'hexdigest/gounit-vim'
+    ```
 *  [NeoBundle](https://github.com/Shougo/neobundle.vim)
-  * `NeoBundle 'buoto/gounit-vim'`
+    ```
+    NeoBundle 'hexdigest/gounit-vim'
+    ```
 *  [Vundle](https://github.com/gmarik/vundle)
-  * `Plugin 'buoto/gounit-vim'`
+    ```
+    Plugin 'hexdigest/gounit-vim'
+    ```
 *  [Vim packages](http://vimhelp.appspot.com/repeat.txt.html#packages) (since Vim 7.4.1528)
-  * `git clone https://github.com/buoto/gounit-vim.git ~/.vim/pack/plugins/start/gounit-vim`
+    ```
+    git clone https://github.com/hexdigest/gounit-vim.git ~/.vim/pack/plugins/start/gounit-vim
+    ```  
+You will also need to install all the necessary GoUnit binaries. 
+It is easy to install by providing a command `:GoUnitInstallBinaries`, which will `go get` all the required binaries.
+
+## Usage
+Call `:GoUnit` to generate test for function in current line (function declaration line) or functions in text selected in visual mode.
+Another example of usage is to give vim "range" parameter:
+```vim
+:5,10GoUnit     " genereate tests for functions from line 5 to line 10
+:.,$GoUnit      " from the current line till the end of the file
+:0,.GoUnit      " from the first line to the current line
+:%GoUnit        " generate tests for the whole file
+```
+
+Also you can create useful maps to use it with [go-vim](https://github.com/fatih/vim-go) plugin for fast function tests generation.
+```vim
+" maps your leader key + gt to generate tests for the function under your cursor
+nnnoremap <leader>gt :normal vaf<cr>:GoUnit<cr>
+```
+
+
 
 ## Settings
 If you want you can set path to your **gounit** binary if it's not in your path, for example:

--- a/plugin/vim-gounit.vim
+++ b/plugin/vim-gounit.vim
@@ -1,4 +1,158 @@
+" Run a shell command.
+"
+" It will temporary set the shell to /bin/sh for Unix-like systems if possible,
+" so that we always use a standard POSIX-compatible Bourne shell (and not e.g.
+" csh, fish, etc.) See #988 and #1276.
+function! s:system(cmd, ...) abort
+  " Preserve original shell and shellredir values
+  let l:shell = &shell
+  let l:shellredir = &shellredir
 
+  try
+    return call('system', [a:cmd] + a:000)
+  finally
+    " Restore original values
+    let &shell = l:shell
+    let &shellredir = l:shellredir
+  endtry
+endfunction
+
+function! s:exec(cmd, ...) abort
+  let l:bin = a:cmd[0]
+  let l:cmd = s:ShellJoin([l:bin] + a:cmd[1:])
+
+  let l:out = call('s:system', [l:cmd] + a:000)
+  return [l:out, s:ShellError()]
+endfunction
+
+function! s:ShellError() abort
+  return v:shell_error
+endfunction
+
+" Shelljoin returns a shell-safe string representation of arglist. The
+" {special} argument of shellescape() may optionally be passed.
+function! s:ShellJoin(arglist, ...) abort
+  try
+    let l:ssl_save = &shellslash
+    set noshellslash
+    if a:0
+      return join(map(copy(a:arglist), 'shellescape(v:val, ' . a:1 . ')'), ' ')
+    endif
+
+    return join(map(copy(a:arglist), 'shellescape(v:val)'), ' ')
+  finally
+    let &shellslash = ssl_save
+  endtry
+endfunction
+
+" Exec runs a shell command cmd, which must be a list, one argument per item.
+" Every list entry will be automatically shell-escaped
+" Every other argument is passed to stdin.
+function! s:ExecCmd(cmd, ...) abort
+  if len(a:cmd) == 0
+    echo "ExecCmd() called with empty a:cmd")
+    return ['', 1]
+  endif
+
+  let l:bin = a:cmd[0]
+
+  " Finally execute the command using the full, resolved path. Do not pass the
+  " unmodified command as the correct program might not exist in $PATH.
+  return call('s:exec', [[l:bin] + a:cmd[1:]] + a:000)
+endfunction
+
+" CheckBinaries checks if the necessary binaries to install the Go tool
+" commands are available.
+function! s:CheckBinaries()
+  if !executable('go')
+    echohl Error | echomsg "vim-go: go executable not found." | echohl None
+    return -1
+  endif
+
+  if !executable('git')
+    echohl Error | echomsg "vim-go: git executable not found." | echohl None
+    return -1
+  endif
+endfunction
+
+" Default returns the default GOPATH. If GOPATH is not set, it uses the
+" default GOPATH set starting with Go 1.8. This GOPATH can be retrieved via
+" 'go env GOPATH'
+function! s:DefaultPath() abort
+  if $GOPATH == ""
+    " use default GOPATH via go env
+    return s:UtilEnv("gopath")
+  endif
+
+  return $GOPATH
+endfunction
+
+" env returns the go environment variable for the given key. Where key can be
+" GOARCH, GOOS, GOROOT, etc... It caches the result and returns the cached
+" version.
+function! s:UtilEnv(key) abort
+  let l:key = tolower(a:key)
+  if has_key(s:env_cache, l:key)
+    return s:env_cache[l:key]
+  endif
+
+  if executable('go')
+    let l:var = call('GoPath', [])
+  else
+    let l:var = eval("$".toupper(a:key))
+  endif
+
+  let s:env_cache[l:key] = l:var
+  return l:var
+endfunction
+
+" gopath returns 'go env GOPATH'. This is an internal function and shouldn't
+" be used. Instead use 'go#util#env("gopath")'
+function! s:GoPath() abort
+  return substitute(s:exec(['go', 'env', 'GOPATH'])[0], '\n', '', 'g')
+endfunction
+
+" main download function for Go-unit
+function! s:GoUnitInstall()
+	if !executable('gounit')
+		" check if we can download and install gounit with go and git
+		let l:err = s:CheckBinaries()
+		if l:err != 0
+			return
+		endif
+		if s:DefaultPath() == ""
+			echohl Error
+			echomsg "vim.go: $GOPATH is not set and 'go env GOPATH' returns empty"
+			echohl None
+			return
+		endif
+		let l:go_bin_path = s:DefaultPath()
+		let l:pluginPath = 'github.com/hexdigest/gounit/cmd/gounit'
+
+		" when shellslash is set on MS-* systems, shellescape puts single quotes
+		" around the output string. cmd on Windows does not handle single quotes
+		" correctly. Unsetting shellslash forces shellescape to use double quotes
+		" instead.
+		let l:resetshellslash = 0
+		if has('win32') && &shellslash
+			let l:resetshellslash = 1
+			set noshellslash
+		endif
+
+		echo "Go: ". "go-unit" ." not found. Installing ". pluginPath . " to folder " . go_bin_path
+		let l:run_cmd = ['go', 'get', '-u']
+		let [l:out, l:err] = s:ExecCmd(l:run_cmd + [l:pluginPath])
+		if l:err
+			echom "Error installing " . pluginPath . ": " . l:out
+		endif
+    echo 'gounit installation is complete'
+  else
+    echo 'gounit is already installed'
+	endif
+endfunction
+
+"""""""""""""""""""""""""""""""""""""""
+" plugin functionality
 if !exists('g:gounit_bin')
     let g:gounit_bin = 'gounit'
 endif
@@ -33,3 +187,4 @@ function! s:Tests() range
 endfunction
 
 command! -range GoUnit <line1>,<line2>call s:Tests()
+command! GoUnitInstallBinaries call s:GoUnitInstall()


### PR DESCRIPTION
Implemented kind of "vim-go" function for downloading gounit binaries through vim. So now you can just connect gounit-vim with your plugin manager and simply use :GoUnitInstallBinaries to download gounit into your $GOPATH. It checks if gounit is already installed and if not it is using `go get` underneath. (I decided to add this command and not to use auto `call` check of the function when plugin loads)
In the future this functionality can be simplified to use less code, but for now this should work fine. 

Also fixed broken links in README file and added exta information there.
